### PR TITLE
処理するファイルを指定できるようにする

### DIFF
--- a/scraping.js
+++ b/scraping.js
@@ -11,7 +11,7 @@ function printError(message) {
 }
 
 if (!process.argv[2]) printError("入力ファイルを指定してください");
-if (!fs.existsSync(process.argv[2])) printError("入力ファイルの指定が不正です");
+if (!fs.existsSync(process.argv[2])) printError("入力ファイルが存在しません");
 const { name } = path.parse(process.argv[2]);
 const html = fs.readFileSync(process.argv[2]);
 const { document } = new JSDOM(html).window;

--- a/scraping.js
+++ b/scraping.js
@@ -23,7 +23,7 @@ try {
   const notes = [...document.querySelectorAll(".note:not(.new)")];
   contents = notes.map((note) => {
     const memo = note.childNodes[2].value;
-    const [, x, y] = note.childNodes[3].textContent.match(pointPattern);
+    const [, x, y] = note.childNodes[3].textContent.match(pointPattern) || [];
     return [memo, x, y].join(separator);
   });
 } catch {

--- a/scraping.js
+++ b/scraping.js
@@ -10,8 +10,8 @@ function printError(message) {
   process.exit(1);
 }
 
-if (!process.argv[2]) printError("");
-if (!fs.existsSync(process.argv[2])) printError("");
+if (!process.argv[2]) printError("入力ファイルを指定してください");
+if (!fs.existsSync(process.argv[2])) printError("入力ファイルの指定が不正です");
 const html = fs.readFileSync(process.argv[2]);
 const { name } = path.parse(process.argv[2]);
 
@@ -34,5 +34,5 @@ try {
   fs.writeFileSync(`${name}.tsv`, tsv);
   console.log(info.flat().join(" "));
 } catch {
-  printError("");
+  printError("結果の出力に失敗しました");
 }


### PR DESCRIPTION
`node scraping.js 1194521074.html` のように、処理するファイルを指定できるようにしました。
これに関連して、以下の4通りでエラーメッセージが出るようにしました。

- 入力ファイルが指定されなかった場合： `node scraping.js`, `node scraping.js ''`
- 入力ファイルが存在しなかった場合： `node scraping.js foo`
- 入力ファイルの解析に失敗した場合： `node scraping.js README.md`
- 結果の書き込みに失敗した場合

これでとりあえず、テストデータの `.html` から `.tsv` を得られるようになります。
また `info.tsv` を見て、テストデータに関しては解析に失敗したケースがないことも確認しました。
（出力された `.tsv` の形式がよくないケースはまだある。）

```sh
$ cd DTBK_DCCdata
$ find . -type f | xargs -n1 node ../scraping.js >> info.tsv

# 生成した .tsv を消す場合は以下のコマンドを実行する
$ find . -type f -name '*.tsv' -delete
```
